### PR TITLE
Fix code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/albums-api/Controllers/UnsecuredController.cs
+++ b/albums-api/Controllers/UnsecuredController.cs
@@ -2,6 +2,7 @@ using Microsoft.Data.SqlClient;
 using System.Data;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Text;
+using System.IO;
 
 namespace UnsecureApp.Controllers
 {
@@ -10,7 +11,20 @@ namespace UnsecureApp.Controllers
 
         public string ReadFile(string userInput)
         {
-            using (FileStream fs = File.Open(userInput, FileMode.Open))
+            if (IsPathTraversal(userInput))
+            {
+                throw new ArgumentException("Invalid file path.");
+            }
+
+            string basePath = "/safe/directory"; // Change this to your safe directory
+            string fullPath = Path.GetFullPath(Path.Combine(basePath, userInput));
+
+            if (!fullPath.StartsWith(basePath))
+            {
+                throw new ArgumentException("Invalid file path.");
+            }
+
+            using (FileStream fs = File.Open(fullPath, FileMode.Open))
             {
                 byte[] b = new byte[1024];
                 UTF8Encoding temp = new UTF8Encoding(true);
@@ -76,5 +90,10 @@ namespace UnsecureApp.Controllers
         }
 
         private string connectionString = "";
+
+        private bool IsPathTraversal(string path)
+        {
+            return path.Contains("..") || path.Contains("/") || path.Contains("\\");
+        }
     }
 }


### PR DESCRIPTION
Fixes [https://github.com/geovanams/GHASdemo/security/code-scanning/1](https://github.com/geovanams/GHASdemo/security/code-scanning/1)

To fix the problem, we need to validate the `userInput` before using it to construct a file path. The best way to do this is to ensure that the `userInput` does not contain any path traversal characters such as "..", "/", or "\\". Additionally, we can ensure that the resolved path is within a specific directory to further mitigate the risk.

1. Add a method to validate the `userInput` to ensure it does not contain any path traversal characters.
2. Use the `Path.GetFullPath` method to resolve the full path and check if it is within a specific directory.
3. Update the `ReadFile` method to include these validations before opening the file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
